### PR TITLE
[COZY-276] 온보딩 스크린 - 칩 선택 스크린 구현

### DIFF
--- a/AppInner.tsx
+++ b/AppInner.tsx
@@ -19,6 +19,7 @@ import RoomMateScreen from 'src/screens/roomMate/roomMate';
 import FeedCreateScreen from 'src/screens/feed/feedCreate';
 import ChatRoomScreen from 'src/screens/chatting/chatRoom';
 import SendChatScreen from 'src/screens/chatting/sendChat';
+import ChipSelectScreen from 'src/screens/onBoard/chipSelect';
 import CreateTodoScreen from 'src/screens/todoList/createTodo';
 import CreateRoomScreen from 'src/screens/createRoom/createRoom';
 import UserDetailScreen from 'src/screens/userDetail/userDetail';
@@ -100,6 +101,7 @@ function AppInner() {
           <rootStack.Screen name="SignInScreen" component={SignInScreen} />
           <rootStack.Screen name="PersonalInfoInputScreen" component={PersonalInfoInputScreen} />
           <rootStack.Screen name="CharacterInputScreen" component={CharacterInputScreen} />
+          <rootStack.Screen name="ChipSelectScreen" component={ChipSelectScreen} />
           <rootStack.Screen name="CompleteScreen" component={CompleteScreen} />
         </rootStack.Navigator>
       )}

--- a/src/components/basicRadioBox.tsx
+++ b/src/components/basicRadioBox.tsx
@@ -4,6 +4,8 @@ import { Text, View, Pressable, TextInput } from 'react-native';
 import RadioButtonSvg from '@assets/onBoard/radioBox.svg';
 import SelectedRadioButtonSvg from '@assets/onBoard/selectedRadioBox.svg';
 
+type Item = { index: number; value: string; item: string; select: boolean };
+
 interface RadioBoxComponentProps {
   title: string;
   value: string;
@@ -11,8 +13,6 @@ interface RadioBoxComponentProps {
   items: Item[];
   setItems: React.Dispatch<React.SetStateAction<Item[]>>;
 }
-
-type Item = { index: number; value: string; item: string; select: boolean };
 
 const RadioBoxComponent: React.FC<RadioBoxComponentProps> = ({
   title,

--- a/src/components/customCheckBox.tsx
+++ b/src/components/customCheckBox.tsx
@@ -43,8 +43,6 @@ const CustomCheckBoxComponent: React.FC<CustomCheckBoxComponentProps> = ({
 
     setItems(updatedItems);
     handleFocus(selectedItem.index);
-
-    console.log(items);
   };
 
   return (
@@ -52,13 +50,13 @@ const CustomCheckBoxComponent: React.FC<CustomCheckBoxComponentProps> = ({
       {items.map((item: Item) => (
         <Pressable
           key={item.index}
-          className={`m-1 flex-row flex-wrap items-center justify-center rounded-[35px] border px-[14px] py-2 ${
+          className={`mb-3 mr-2 flex-row flex-wrap items-center justify-center rounded-full border px-[14px] py-2 ${
             item.select ? 'border-main1 bg-sub1' : 'border-disabled bg-white'
           }`}
           onPress={() => select(item)}
         >
           <Text
-            className={`text-sm font-medium ${item.select ? 'text-main1' : 'text-disabledFont'}`}
+            className={`text-center text-sm font-medium tracking-tighter ${item.select ? 'text-main1' : 'text-disabledFont'}`}
           >
             {item.name}
           </Text>

--- a/src/components/customCheckBox.tsx
+++ b/src/components/customCheckBox.tsx
@@ -1,19 +1,19 @@
 import React, { useState } from 'react';
 import { Text, Pressable } from 'react-native';
 
-interface CustomCheckBoxComponentProps {
-  value: string[];
-  setValue: React.Dispatch<React.SetStateAction<string[]>>;
-  items: Item[];
-  setItems: React.Dispatch<React.SetStateAction<Item[]>>;
-}
-
 type Item = {
   index: number;
   id: string;
   name: string;
   select: boolean;
 };
+
+interface CustomCheckBoxComponentProps {
+  value: string[];
+  setValue: React.Dispatch<React.SetStateAction<string[]>>;
+  items: Item[];
+  setItems: React.Dispatch<React.SetStateAction<Item[]>>;
+}
 
 const CustomCheckBoxComponent: React.FC<CustomCheckBoxComponentProps> = ({
   value,

--- a/src/components/onBoard/dateSelectModal.tsx
+++ b/src/components/onBoard/dateSelectModal.tsx
@@ -17,6 +17,7 @@ const DateSelectModal: React.FC<DatePickerComponentProps> = ({
   title,
 }) => {
   const [isFocused, setIsFocused] = useState<boolean>(false);
+  const [isDatePickerVisible, setDatePickerVisibility] = useState(false);
 
   const inputRef = React.useRef<TextInput>(null);
 
@@ -34,8 +35,6 @@ const DateSelectModal: React.FC<DatePickerComponentProps> = ({
   const handleBlur = () => {
     setIsFocused(false);
   };
-
-  const [isDatePickerVisible, setDatePickerVisibility] = useState(false);
 
   const hideDatePicker = () => {
     setDatePickerVisibility(false);

--- a/src/components/onBoard/schoolSelect.tsx
+++ b/src/components/onBoard/schoolSelect.tsx
@@ -1,0 +1,60 @@
+import React, { useState } from 'react';
+import { View, Text, Pressable, TextInput } from 'react-native';
+
+import DownArrow from '@assets/onBoard/downArrow.svg';
+
+interface SchoolSelectProps {
+  school: string;
+  setSchool: React.Dispatch<React.SetStateAction<string>>;
+  title: string;
+}
+
+const SchoolSelect: React.FC<SchoolSelectProps> = ({ school, setSchool, title }) => {
+  const inputRef = React.useRef<TextInput>(null);
+  const [isFocused, setIsFocused] = useState<boolean>(false);
+
+  // TextInput 밖에 영역 클릭 시에도 focusing 하게 하는 함수
+  const handleFocus = () => {
+    setIsFocused(true);
+
+    if (inputRef.current) {
+      inputRef.current.focus();
+    }
+  };
+
+  // 다른 곳에 focusing 옮겨졌을때 기존 focusing 없애는 함수
+  const handleBlur = () => {
+    setIsFocused(false);
+  };
+
+  const isActive = isFocused || school !== '';
+
+  return (
+    <Pressable
+      onPress={handleFocus}
+      className={`mb-4 box-border flex flex-row items-center justify-between rounded-xl border bg-white px-5 py-4
+        ${isActive ? 'border-sub1' : 'border-disabled'}`}
+    >
+      <View className="flex flex-col items-start justify-center">
+        <Text
+          className={`text-xs font-semibold leading-[17px] tracking-tight
+            ${isFocused ? 'text-main1' : 'text-colorFont'}`}
+        >
+          {title}
+        </Text>
+        <View className="mt-1.5 flex w-full flex-row items-center justify-between pb-[3px]">
+          <Text
+            className={`${school === '' ? 'text-sm text-disabledFont' : 'text-xs text-basicFont'} font-medium`}
+          >
+            {school === '' ? '학교를 선택해주세요' : school}
+          </Text>
+          <DownArrow />
+        </View>
+      </View>
+
+      <TextInput className="hidden" ref={inputRef} onBlur={handleBlur} />
+    </Pressable>
+  );
+};
+
+export default SchoolSelect;

--- a/src/components/roomMate/checkBoxContainer.tsx
+++ b/src/components/roomMate/checkBoxContainer.tsx
@@ -24,7 +24,7 @@ const CheckBoxContainer: React.FC<CheckBoxContainerProps> = ({
   setItems,
 }) => {
   return (
-    <View className="mb-6 px-3">
+    <View className="mb-6 pl-5 pr-3">
       <View className="flex-row flex-wrap">
         <CustomCheckBoxComponent
           value={value}

--- a/src/screens/onBoard/character.tsx
+++ b/src/screens/onBoard/character.tsx
@@ -153,7 +153,7 @@ const CharacterInputScreen = ({ navigation }: CharacterInputScreenProps) => {
       persona: character,
     }));
 
-    navigation.navigate('CompleteScreen');
+    navigation.navigate('ChipSelectScreen');
   };
 
   return (

--- a/src/screens/onBoard/character.tsx
+++ b/src/screens/onBoard/character.tsx
@@ -148,6 +148,8 @@ const CharacterInputScreen = ({ navigation }: CharacterInputScreenProps) => {
   ]);
 
   const toNext = async (): Promise<void> => {
+    if (!isComplete) return;
+
     setSignUp((prevState: SignUp) => ({
       ...prevState,
       persona: character,

--- a/src/screens/onBoard/chipSelect.tsx
+++ b/src/screens/onBoard/chipSelect.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { SafeAreaView } from 'react-native';
+
+const ChipSelectScreen = () => {
+  return <SafeAreaView></SafeAreaView>;
+};
+
+export default ChipSelectScreen;

--- a/src/screens/onBoard/chipSelect.tsx
+++ b/src/screens/onBoard/chipSelect.tsx
@@ -35,11 +35,12 @@ const ChipSelectScreen = ({ navigation }: ChipSelectScreenProps) => {
     { index: 24, id: 'mbti', name: 'MBTI', select: false },
   ]);
 
-  const toNext = () => {
+  const isComplete = selectedChips.length === 4;
+
+  const toNext = async (): Promise<void> => {
+    if (!isComplete) return;
     navigation.navigate('CompleteScreen');
   };
-
-  const isComplete = selectedChips.length === 4;
 
   return (
     <SafeAreaView className="flex-1 bg-white">

--- a/src/screens/onBoard/chipSelect.tsx
+++ b/src/screens/onBoard/chipSelect.tsx
@@ -1,8 +1,78 @@
-import React from 'react';
-import { SafeAreaView } from 'react-native';
+import React, { useState, useEffect } from 'react';
+import { Text, View, Pressable, SafeAreaView } from 'react-native';
 
-const ChipSelectScreen = () => {
-  return <SafeAreaView></SafeAreaView>;
+import CheckBoxContainer from '@components/roomMate/checkBoxContainer';
+
+import { ChipSelectScreenProps } from '@type/param/rootStack';
+
+const ChipSelectScreen = ({ navigation }: ChipSelectScreenProps) => {
+  const [selectedChips, setSelectedChips] = useState<string[]>([]);
+
+  const [items, setItems] = useState([
+    { index: 1, id: 'birthYear', name: '출생년도', select: false },
+    { index: 2, id: 'admissionYear', name: '학번', select: false },
+    { index: 3, id: 'major', name: '학과', select: false },
+    { index: 4, id: 'acceptance', name: '합격여부', select: false },
+    { index: 5, id: 'wakeUpTime', name: '기상시간', select: false },
+    { index: 6, id: 'sleepingTime', name: '취침시간', select: false },
+    { index: 7, id: 'turnOffTime', name: '소등시간', select: false },
+    { index: 8, id: 'smoking', name: '흡연여부', select: false },
+    { index: 9, id: 'sleepingHabit', name: '잠버릇', select: false },
+    { index: 10, id: 'airConditioningIntensity', name: '에어컨', select: false },
+    { index: 11, id: 'heatingIntensity', name: '히터', select: false },
+    { index: 12, id: 'lifePattern', name: '생활패턴', select: false },
+    { index: 13, id: 'intimacy', name: '친밀도', select: false },
+    { index: 14, id: 'canShare', name: '물건공유', select: false },
+    { index: 15, id: 'isPlayGame', name: '게임여부', select: false },
+    { index: 16, id: 'isPhoneCall', name: '전화여부', select: false },
+    { index: 17, id: 'studying', name: '공부여부', select: false },
+    { index: 18, id: 'intake', name: '섭취여부', select: false },
+    { index: 19, id: 'cleanSensitivity', name: '청결예민도', select: false },
+    { index: 20, id: 'noiseSensitivity', name: '소음예민도', select: false },
+    { index: 21, id: 'cleaningFrequency', name: '청소빈도', select: false },
+    { index: 22, id: 'drinkingFrequency', name: '음주빈도', select: false },
+    { index: 23, id: 'personality', name: '성격', select: false },
+    { index: 24, id: 'mbti', name: 'MBTI', select: false },
+  ]);
+
+  const toNext = () => {
+    navigation.navigate('CompleteScreen');
+  };
+
+  const isComplete = selectedChips.length === 4;
+
+  return (
+    <SafeAreaView className="flex-1 bg-white">
+      <View className="flex flex-1 flex-col justify-between">
+        {/* 상단 View */}
+        <View className="mt-14 flex">
+          {/* 설명 Text */}
+          <View className="mb-6 px-5 leading-loose">
+            <Text className="text-xl font-semibold tracking-tight text-emphasizedFont">
+              룸메이트를 선택할 때,{'\n'}가장 중요한 요소 <Text className="text-main1">4가지</Text>
+              를 선택해주세요
+            </Text>
+          </View>
+
+          <CheckBoxContainer
+            value={selectedChips}
+            setValue={setSelectedChips}
+            items={items}
+            setItems={setItems}
+          />
+        </View>
+
+        {/* 하단 View */}
+        <View className="flex px-5">
+          <Pressable onPress={toNext}>
+            <View className={`rounded-xl p-4 ${isComplete ? 'bg-main1' : 'bg-[#C4C4C4]'}`}>
+              <Text className="text-center text-base font-semibold text-white">확인</Text>
+            </View>
+          </Pressable>
+        </View>
+      </View>
+    </SafeAreaView>
+  );
 };
 
 export default ChipSelectScreen;

--- a/src/screens/onBoard/personalInfo.tsx
+++ b/src/screens/onBoard/personalInfo.tsx
@@ -4,6 +4,7 @@ import { TouchableWithoutFeedback } from 'react-native';
 import { Text, View, Keyboard, Pressable, SafeAreaView } from 'react-native';
 
 import RadioBoxComponent from '@components/basicRadioBox';
+import SchoolSelect from '@components/onBoard/schoolSelect';
 import DateSelectModal from '@components/onBoard/dateSelectModal';
 import BorderTextInputBox from '@components/common/borderTextInputBox';
 
@@ -15,12 +16,13 @@ import { checkNickname } from '@server/api/member';
 import { PersonalInfoInputScreenProps } from '@type/param/rootStack';
 
 const PersonalInfoInputScreen = ({ navigation }: PersonalInfoInputScreenProps) => {
-  const [signUp, setSignUp] = useRecoilState(signUpState);
+  const [, setSignUp] = useRecoilState(signUpState);
 
   const [name, setName] = useState<string>('');
   const [nickname, setNickname] = useState<string>('');
   const [gender, setGender] = useState<string>('');
   const [birthday, setBirthday] = useState<string>('');
+  const [school, setSchool] = useState<string>('');
 
   const isComplete = name !== '' && nickname !== '' && gender !== '' && birthday !== '';
 
@@ -75,7 +77,7 @@ const PersonalInfoInputScreen = ({ navigation }: PersonalInfoInputScreenProps) =
     if (checkDuplicate) {
       setCanUse(true);
     }
-  }, [nickname]);
+  }, [nickname, checkDuplicate]);
 
   const toNext = async (): Promise<void> => {
     if (!isComplete || !canUse) return;
@@ -155,6 +157,9 @@ const PersonalInfoInputScreen = ({ navigation }: PersonalInfoInputScreenProps) =
               setSelectedDate={setBirthday}
               title="생년월일"
             />
+
+            {/* 학교 입력 Input */}
+            <SchoolSelect school={school} setSchool={setSchool} title="학교" />
           </View>
 
           {/* 하단 View */}

--- a/src/screens/signIn/signIn.tsx
+++ b/src/screens/signIn/signIn.tsx
@@ -25,6 +25,10 @@ const SignInScreen = ({ navigation }: SignInScreenProps) => {
 
   const loginWithId = useLoginWithId(navigation);
 
+  const toOnboard = () => {
+    navigation.navigate('PersonalInfoInputScreen');
+  };
+
   return (
     <SafeAreaView className="flex-1 bg-white">
       <View className="mx-6 flex-1">
@@ -69,6 +73,10 @@ const SignInScreen = ({ navigation }: SignInScreenProps) => {
             <Text className="text-center text-base font-semibold text-white">Apple로 계속하기</Text>
           </Pressable>
         </View>
+
+        <Pressable onPress={toOnboard}>
+          <Text>온보딩</Text>
+        </Pressable>
       </View>
     </SafeAreaView>
   );

--- a/src/screens/signIn/signIn.tsx
+++ b/src/screens/signIn/signIn.tsx
@@ -26,7 +26,7 @@ const SignInScreen = ({ navigation }: SignInScreenProps) => {
   const loginWithId = useLoginWithId(navigation);
 
   const toOnboard = () => {
-    navigation.navigate('PersonalInfoInputScreen');
+    navigation.navigate('ChipSelectScreen');
   };
 
   return (

--- a/src/type/param/rootStack.ts
+++ b/src/type/param/rootStack.ts
@@ -4,6 +4,7 @@ export type RootStackParamList = {
   SignInScreen: undefined;
   PersonalInfoInputScreen: undefined;
   CharacterInputScreen: undefined;
+  ChipSelectScreen: undefined;
   CompleteScreen: undefined;
 };
 
@@ -21,6 +22,9 @@ export type CharacterInputScreenProps = NativeStackScreenProps<
   RootStackParamList,
   'CharacterInputScreen'
 >;
+
+// 온보딩 3 스크린
+export type ChipSelectScreenProps = NativeStackScreenProps<RootStackParamList, 'ChipSelectScreen'>;
 
 // 온보딩 완료 스크린
 export type CompleteScreenProps = NativeStackScreenProps<RootStackParamList, 'CompleteScreen'>;


### PR DESCRIPTION
## 🚩 관련 이슈 (Jira)
[COZY-276] 온보딩 스크린 - 칩 선택 스크린 구현

## 📌 반영 브랜치
COZY-276 -> dev

## 📋 내용
### 💻 온보딩 스크린 - 칩 선택 스크린
- [x] 설명 텍스트 및 칩 컴포넌트 생성
- [x] 4개 선택 시 다음 스크린으로 이동 가능하도록 구현
<img src="https://github.com/user-attachments/assets/6ed5f372-0815-48f5-9ea0-fb64395a9f5d" width="250" />
<img src="https://github.com/user-attachments/assets/11fed8a2-241b-4e67-840e-7d87d169eb3e" width="250" />

## 🚨 유의 사항
- [ ] 어플 시작 화면에 온보딩 스크린을 테스트하기 위한 Pressable 존재 (이후 삭제 필요)
- [ ] 4개 이상 선택해도 경고 문구 등의 효과가 없음 (다음으로 넘어가지는 못함)


[COZY-276]: https://cozymate.atlassian.net/browse/COZY-276?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ