### PR TITLE
[COZY-658] 코지홈 화면 리팩토링 작업

### DIFF
--- a/components/common/roomItem/basicRoomItem.tsx
+++ b/components/common/roomItem/basicRoomItem.tsx
@@ -1,6 +1,7 @@
 import { useRouter } from 'expo-router';
-import { Pressable, Text, View } from 'react-native';
+import { Text, View } from 'react-native';
 
+import OpacityPressable from '@/components/opacityPressable';
 import { RecommendRoomItem } from '@/type/room';
 import { getLifeStyleIcon, getLifeStyleLabel } from '@/utils/lifeStyle';
 
@@ -9,7 +10,7 @@ interface BasicRoomItemProps {
   onPress?: () => void;
 }
 
-const BasicRoomItem: React.FC<BasicRoomItemProps> = ({ roomData, onPress = () => {} }) => {
+export default function BasicRoomItem({ roomData, onPress = () => {} }: BasicRoomItemProps) {
   const router = useRouter();
 
   const getChipColor = (numOfArrival: number, count: number) => {
@@ -28,7 +29,7 @@ const BasicRoomItem: React.FC<BasicRoomItemProps> = ({ roomData, onPress = () =>
   };
 
   return (
-    <Pressable onPress={handlePress}>
+    <OpacityPressable onPress={handlePress}>
       <View className="border border-disabledColor px-[16px] pt-[20px] pb-[18px] rounded-xl mx-[20px]">
         <View className="flex flex-row items-center justify-between">
           <Text className="Semibold16 text-basicFont mx-[8px]">{roomData.name}</Text>
@@ -79,8 +80,6 @@ const BasicRoomItem: React.FC<BasicRoomItemProps> = ({ roomData, onPress = () =>
           </View>
         </View>
       </View>
-    </Pressable>
+    </OpacityPressable>
   );
-};
-
-export default BasicRoomItem;
+}

--- a/components/common/userItem/basicUserItem.tsx
+++ b/components/common/userItem/basicUserItem.tsx
@@ -1,6 +1,7 @@
 import { useRouter } from 'expo-router';
-import { Pressable, Text, View } from 'react-native';
+import { Text, View } from 'react-native';
 
+import OpacityPressable from '@/components/opacityPressable';
 import { MemberItem } from '@/type/member';
 import { getLifeStyleIcon, getLifeStyleLabel, getLifeStyleValue } from '@/utils/lifeStyle';
 
@@ -9,7 +10,7 @@ interface BasicUserItemProps {
   onPress?: () => void;
 }
 
-const BasicUserItem: React.FC<BasicUserItemProps> = ({ userData, onPress = () => {} }) => {
+export default function BasicUserItem({ userData, onPress = () => {} }: BasicUserItemProps) {
   const router = useRouter();
 
   const handlePress = () => {
@@ -18,7 +19,7 @@ const BasicUserItem: React.FC<BasicUserItemProps> = ({ userData, onPress = () =>
   };
 
   return (
-    <Pressable onPress={handlePress}>
+    <OpacityPressable onPress={handlePress}>
       <View className="border border-disabledColor px-[16px] pt-[20px] pb-[18px] rounded-xl mx-[20px]">
         <View className="flex flex-row items-center justify-between">
           <Text className="Semibold16 text-basicFont mx-[8px]">
@@ -58,8 +59,6 @@ const BasicUserItem: React.FC<BasicUserItemProps> = ({ userData, onPress = () =>
           </View>
         </View>
       </View>
-    </Pressable>
+    </OpacityPressable>
   );
-};
-
-export default BasicUserItem;
+}

--- a/components/cozyHome/header.tsx
+++ b/components/cozyHome/header.tsx
@@ -1,6 +1,5 @@
 import { useRouter } from 'expo-router';
-import { useState } from 'react';
-import { Dimensions, Pressable, Text, View } from 'react-native';
+import { Dimensions, Text, View } from 'react-native';
 
 import ChatIcon from '@/assets/images/common/chat.svg';
 import GrayArrow from '@/assets/images/common/grayArrow.svg';
@@ -8,43 +7,17 @@ import NotificationIcon from '@/assets/images/common/notification.svg';
 import Background from '@/assets/images/cozyHome/background.svg';
 import SchoolIcon from '@/assets/images/cozyHome/blueSchoolIcon.svg';
 import Magnifier from '@/assets/images/cozyHome/magnifier.svg';
-import TwoButtonModal from '@/components/modal/twoButtonModal';
-import { useCheckHasRoom } from '@/hooks/room/room';
 import { useTracker } from '@/providers/TrackerProvider';
 import { ButtonEvent, EventCategory } from '@/utils/ga/eventEnum';
 import { useMemberStore } from '@/zustand/store';
 
-const HeaderComponent: React.FC = () => {
-  const width = Dimensions.get('screen').width;
+import OpacityPressable from '../opacityPressable';
 
+export default function HeaderComponent() {
   const router = useRouter();
 
-  const { trackButton } = useTracker();
-
   const { memberInfo, hasLifeStyle } = useMemberStore();
-
-  const { data: hasRoom } = useCheckHasRoom();
-
-  const [showNoLifeStyleCreateModal, setShowNoLifeStyleCreateModal] = useState<boolean>(false);
-  const [showNoLifeStyleJoinModal, setShowNoLifeStyleJoinModal] = useState<boolean>(false);
-
-  const handleCreateRoom = () => {
-    if (!hasLifeStyle) {
-      setShowNoLifeStyleCreateModal(true);
-    } else {
-      trackButton(ButtonEvent.make_room, EventCategory.home_header);
-      router.push('/room/createRoom');
-    }
-  };
-
-  const handleJoinRoom = () => {
-    if (!hasLifeStyle) {
-      setShowNoLifeStyleJoinModal(true);
-    } else {
-      trackButton(ButtonEvent.join_room, EventCategory.home_header);
-      router.push('/room/joinRoom');
-    }
-  };
+  const { trackButton } = useTracker();
 
   const handleChat = () => {
     trackButton(ButtonEvent.chat, EventCategory.home_header);
@@ -62,91 +35,51 @@ const HeaderComponent: React.FC = () => {
   };
 
   return (
-    <View className="gap-y-[12px] px-[20px] pt-[18px] pb-[25px] bg-subColor1 relative">
-      <Background style={{ position: 'absolute', top: -47 }} width={width} />
+    <View
+      className={`${hasLifeStyle ? 'h-[201px]' : 'h-[127px]'} pt-[65px] gap-y-[12px] px-[20px] bg-subColor1 relative`}
+    >
+      <Background
+        style={{ position: 'absolute', top: 0 }}
+        width={Dimensions.get('screen').width}
+        height={hasLifeStyle ? 201 : 127}
+        preserveAspectRatio="xMidYMid slice"
+      />
       <View className="flex flex-row justify-between items-center">
-        <Pressable onPress={() => router.push('/lifeStyle/basicInfo')}>
-          <View className="flex flex-row items-center gap-x-[6px]">
-            <SchoolIcon />
-            <Text className="Semibold18 text-mainColor">{memberInfo?.universityName ?? ''}</Text>
-          </View>
-        </Pressable>
+        <View className="flex flex-row items-center gap-x-[6px]">
+          <SchoolIcon />
+          <Text className="Semibold18 text-mainColor">{memberInfo?.universityName ?? ''}</Text>
+        </View>
 
         <View className="flex flex-row justify-between items-center">
-          <Pressable onPress={handleChat} className="p-[10px]">
-            <ChatIcon />
-          </Pressable>
+          <OpacityPressable onPress={handleChat}>
+            <View className="p-[10px]">
+              <ChatIcon />
+            </View>
+          </OpacityPressable>
 
-          <Pressable onPress={handleNotice} className="p-[10px]">
-            <NotificationIcon />
-          </Pressable>
+          <OpacityPressable onPress={handleNotice}>
+            <View className="p-[10px]">
+              <NotificationIcon />
+            </View>
+          </OpacityPressable>
         </View>
       </View>
 
-      {!hasLifeStyle && (
-        <Pressable
-          onPress={handleLifeStyle}
-          className="bg-colorBox py-[12px] px-[16px] flex flex-row justify-between items-center rounded-xl"
-        >
-          <View className="gap-x-[8px] flex flex-row items-center">
-            <Magnifier />
-            <Text className="Semibold12 text-basicFont">
-              {memberInfo?.nickname ?? ''}님, 라이프스타일을 입력하고{'\n'}나와 꼭 맞는 룸메이트를
-              찾아볼까요?
-            </Text>
+      {hasLifeStyle && (
+        <OpacityPressable onPress={handleLifeStyle}>
+          <View className="bg-colorBox py-[12px] px-[16px] flex flex-row justify-between items-center rounded-xl">
+            <View className="gap-x-[8px] flex flex-row items-center">
+              <Magnifier />
+              <Text className="Semibold12 text-basicFont">
+                {memberInfo?.nickname ?? ''}님, 라이프스타일을 입력하고{'\n'}나와 꼭 맞는 룸메이트를
+                찾아볼까요?
+              </Text>
+            </View>
+
+            <GrayArrow />
           </View>
-
-          <GrayArrow />
-        </Pressable>
+        </OpacityPressable>
       )}
-
-      <View className="flex flex-row items-center gap-x-[11px]">
-        <Pressable
-          disabled={hasRoom.result.roomId !== 0}
-          onPress={handleCreateRoom}
-          className="bg-colorBox p-[16px] rounded-xl flex-1 h-[80px]"
-        >
-          <Text
-            className={`Semibold16 ${hasRoom.result.roomId !== 0 ? 'text-disabledFont' : 'text-mainColor'}`}
-          >
-            방 만들기
-          </Text>
-        </Pressable>
-
-        <TwoButtonModal
-          isVisible={showNoLifeStyleCreateModal}
-          title={`방을 만들려면\n라이프스타일을 입력해야해요!`}
-          closeFunc={() => setShowNoLifeStyleCreateModal(false)}
-          leftButtonText="안할래요"
-          leftButtonFunc={() => setShowNoLifeStyleCreateModal(false)}
-          rightButtonText="할래요"
-          rightButtonFunc={() => router.push('/lifeStyle/onboarding')}
-        />
-
-        <Pressable
-          disabled={hasRoom.result.roomId !== 0}
-          onPress={handleJoinRoom}
-          className="bg-colorBox p-[16px] rounded-xl flex-1 h-[80px]"
-        >
-          <Text
-            className={`Semibold16 ${hasRoom.result.roomId !== 0 ? 'text-disabledFont' : 'text-mainColor'}`}
-          >
-            방 참여하기
-          </Text>
-        </Pressable>
-
-        <TwoButtonModal
-          isVisible={showNoLifeStyleJoinModal}
-          title={`방에 입장하려면\n라이프스타일을 입력해야해요!`}
-          closeFunc={() => setShowNoLifeStyleJoinModal(false)}
-          leftButtonText="안할래요"
-          leftButtonFunc={() => setShowNoLifeStyleJoinModal(false)}
-          rightButtonText="할래요"
-          rightButtonFunc={() => router.push('/lifeStyle/onboarding')}
-        />
-      </View>
     </View>
   );
-};
-
-export default HeaderComponent;
+}

--- a/components/cozyHome/myRoom.tsx
+++ b/components/cozyHome/myRoom.tsx
@@ -1,73 +1,59 @@
 import { useRouter } from 'expo-router';
 import { Pressable, Text, View } from 'react-native';
 
-import { useCheckHasRoom, useGetMyRoomDetail } from '@/hooks/room/room';
+import { useGetMyRoomDetail } from '@/hooks/room/room';
 import { useTracker } from '@/providers/TrackerProvider';
 import { ButtonEvent, EventCategory } from '@/utils/ga/eventEnum';
 import { useMemberStore } from '@/zustand/store';
 
-const MyRoomComponent: React.FC = () => {
+export default function MyRoomComponent() {
   const router = useRouter();
   const { trackButton } = useTracker();
 
-  const { memberInfo, hasLifeStyle } = useMemberStore();
+  const { memberInfo, hasRoom, roomInfo } = useMemberStore();
 
-  const { data: hasRoom } = useCheckHasRoom();
-  const { data } = useGetMyRoomDetail(hasRoom.result.roomId);
+  const { data } = useGetMyRoomDetail(roomInfo?.roomId ?? 0);
 
   const handleRoomPress = () => {
-    trackButton(ButtonEvent.my_room, EventCategory.home_content);
-    router.push(`/room/${hasRoom.result.roomId}`);
+    if (hasRoom && roomInfo !== undefined && roomInfo.roomId !== 0) {
+      trackButton(ButtonEvent.my_room, EventCategory.home_content);
+      router.push(`/room/${roomInfo?.roomId}`);
+    }
   };
 
   return (
-    hasLifeStyle && (
-      <View>
-        <View className="gap-y-[16px] px-[20px]">
-          <View className="gap-y-[2px] mx-[4px]">
-            <Text className="Semibold18 text-emphasizedFont">{memberInfo?.nickname ?? ''}님이</Text>
-            <Text className="Semibold18 text-emphasizedFont">현재 참여하고있는 방이에요</Text>
-          </View>
-
-          {hasRoom.result.roomId !== 0 ? (
-            <Pressable
-              onPress={handleRoomPress}
-              className="rounded-xl p-[16px] gap-y-[8px] border border-mainColor bg-subColor2"
-            >
-              <View className="flex flex-row gap-x-[8px]">
-                {data?.result.hashtagList.map((hash, index) => (
-                  <View key={index} className="bg-white rounded px-[8px] py-[2px]">
-                    <Text className="Medium12 text-colorFont">#{hash}</Text>
-                  </View>
-                ))}
-              </View>
-
-              <Text className="Semibold16 text-emphasizedFont">{data?.result.name}</Text>
-
-              <View className="flex flex-row justify-between items-center">
-                <Text className="Medium12 text-disabledFont">
-                  <Text className="text-mainColor">{data?.result.arrivalMateNum}명</Text>의
-                  룸메이트가 있어요
-                </Text>
-                <Text className="Medium16 text-colorFont">{data?.result.equality ?? '?? '}%</Text>
-              </View>
-            </Pressable>
-          ) : (
-            <View className="p-[20px] gap-y-[6px] mt-[16px]">
-              <Text className="Medium14 text-disabledFont text-center">
-                아직 참여하고 있는 방이 없어요
-              </Text>
-              <Text className="Medium14 text-disabledFont text-center">
-                방을 만들거나, 방에 참여해보세요!
-              </Text>
-            </View>
-          )}
+    <View>
+      <View className="gap-y-[16px] px-[20px]">
+        <View className="gap-y-[2px] mx-[4px]">
+          <Text className="Semibold18 text-emphasizedFont">{memberInfo?.nickname ?? ''}님이</Text>
+          <Text className="Semibold18 text-emphasizedFont">현재 참여하고있는 방이에요</Text>
         </View>
 
-        <View className="bg-[#F7F9FA] w-full h-[10px] mt-[24px]" />
-      </View>
-    )
-  );
-};
+        <Pressable
+          onPress={handleRoomPress}
+          className="rounded-xl p-[16px] gap-y-[8px] border border-mainColor bg-subColor2"
+        >
+          <View className="flex flex-row gap-x-[8px]">
+            {data?.result.hashtagList.map((hash, index) => (
+              <View key={index} className="bg-white rounded px-[8px] py-[2px]">
+                <Text className="Medium12 text-colorFont">#{hash}</Text>
+              </View>
+            ))}
+          </View>
 
-export default MyRoomComponent;
+          <Text className="Semibold16 text-emphasizedFont">{data?.result.name}</Text>
+
+          <View className="flex flex-row justify-between items-center">
+            <Text className="Medium12 text-disabledFont">
+              <Text className="text-mainColor">{data?.result.arrivalMateNum}명</Text>의 룸메이트가
+              있어요
+            </Text>
+            <Text className="Medium16 text-colorFont">{data?.result.equality ?? '?? '}%</Text>
+          </View>
+        </Pressable>
+      </View>
+
+      <View className="bg-[#F7F9FA] w-full h-[10px] mt-[24px]" />
+    </View>
+  );
+}

--- a/components/cozyHome/receivedRequest.tsx
+++ b/components/cozyHome/receivedRequest.tsx
@@ -3,20 +3,20 @@ import { Pressable, Text, View } from 'react-native';
 
 import BlueRightArrowIcon from '@/assets/images/common/blueRightArrow.svg';
 import GrayArrowIcon from '@/assets/images/common/grayArrow.svg';
-import { useCheckHasRoom } from '@/hooks/room/room';
 import { useGetReceivedRequestList } from '@/hooks/room/roomManager';
 import { useTracker } from '@/providers/TrackerProvider';
 import { ButtonEvent, EventCategory } from '@/utils/ga/eventEnum';
+import { useMemberStore } from '@/zustand/store';
 
 import SimpleUserItem from '../common/userItem/simpleUserItem';
 
-const ReceivedRequestComponent: React.FC = () => {
+export default function ReceivedRequestComponent() {
   const router = useRouter();
   const { trackButton } = useTracker();
 
-  const { data: hasRoom } = useCheckHasRoom();
+  const { roomInfo } = useMemberStore();
 
-  const { data } = useGetReceivedRequestList(hasRoom.result.isRoomManager);
+  const { data } = useGetReceivedRequestList(roomInfo?.isRoomManager ?? false);
 
   const handleMore = () => {
     trackButton(ButtonEvent.request_more, EventCategory.home_content);
@@ -30,52 +30,47 @@ const ReceivedRequestComponent: React.FC = () => {
   };
 
   return (
-    hasRoom.result.roomId !== 0 &&
-    hasRoom.result.isRoomManager && (
-      <View>
-        <View className="gap-y-[16px] px-[20px]">
-          <View className="flex flex-row justify-between items-center">
-            <View className="gap-y-[4px] ml-[4px]">
-              <Text
-                className={`Semibold18 ${data?.result.length !== 0 ? 'text-emphasizedFont' : 'text-colorFont'} `}
-              >
-                {data?.result.length ?? 0}개의
-              </Text>
-              <Text className="Semibold18 text-emphasizedFont">방 참여 요청이 도착했어요</Text>
-            </View>
-
-            <Pressable onPress={handleMore}>
-              <View className="flex flex-row items-center gap-x-[4px]">
-                <Text className="Semibold12 text-disabledFont">더보기</Text>
-                <GrayArrowIcon />
-              </View>
-            </Pressable>
+    <View>
+      <View className="gap-y-[16px] px-[20px]">
+        <View className="flex flex-row justify-between items-center">
+          <View className="gap-y-[4px] ml-[4px]">
+            <Text
+              className={`Semibold18 ${data?.result.length !== 0 ? 'text-emphasizedFont' : 'text-colorFont'}`}
+            >
+              {data?.result.length ?? 0}개의
+            </Text>
+            <Text className="Semibold18 text-emphasizedFont">방 참여 요청이 도착했어요</Text>
           </View>
 
-          {data?.result.length !== 0 ? (
-            data?.result.map((member) => (
-              <SimpleUserItem key={member.memberId} userData={member} onPress={handleUserPress} />
-            ))
-          ) : (
-            <View className="mt-[32px] mb-[24px]">
-              <Text className="Medium14 text-disabledFont text-center pt-[8px]">
-                직접 룸메이트를 찾으러 가볼까요?
-              </Text>
-              <Pressable
-                onPress={() => router.push('/user/roomMate')}
-                className="p-[8px] gap-x-[8px] flex flex-row justify-center items-center"
-              >
-                <Text className="Semibold16 text-mainColor text-center">룸메이트 찾으러 가기</Text>
-                <BlueRightArrowIcon />
-              </Pressable>
+          <Pressable onPress={handleMore}>
+            <View className="flex flex-row items-center gap-x-[4px]">
+              <Text className="Semibold12 text-disabledFont">더보기</Text>
+              <GrayArrowIcon />
             </View>
-          )}
+          </Pressable>
         </View>
 
-        <View className="bg-[#F7F9FA] w-full h-[10px] mt-[24px]" />
+        {data?.result.length !== 0 ? (
+          data?.result.map((member) => (
+            <SimpleUserItem key={member.memberId} userData={member} onPress={handleUserPress} />
+          ))
+        ) : (
+          <View className="mt-[32px] mb-[24px]">
+            <Text className="Medium14 text-disabledFont text-center pt-[8px]">
+              직접 룸메이트를 찾으러 가볼까요?
+            </Text>
+            <Pressable
+              onPress={() => router.push('/user/roomMate')}
+              className="p-[8px] gap-x-[8px] flex flex-row justify-center items-center"
+            >
+              <Text className="Semibold16 text-mainColor text-center">룸메이트 찾으러 가기</Text>
+              <BlueRightArrowIcon />
+            </Pressable>
+          </View>
+        )}
       </View>
-    )
-  );
-};
 
-export default ReceivedRequestComponent;
+      <View className="bg-[#F7F9FA] w-full h-[10px] mt-[24px]" />
+    </View>
+  );
+}

--- a/components/cozyHome/recommendRoom.tsx
+++ b/components/cozyHome/recommendRoom.tsx
@@ -1,7 +1,6 @@
 import { useRouter } from 'expo-router';
 import React, { Fragment } from 'react';
 import { Dimensions, Text, View } from 'react-native';
-import { Pressable } from 'react-native-gesture-handler';
 import { useSharedValue } from 'react-native-reanimated';
 import Carousel, { Pagination } from 'react-native-reanimated-carousel';
 
@@ -12,7 +11,9 @@ import { useTracker } from '@/providers/TrackerProvider';
 import { ButtonEvent, EventCategory, GestureEvent } from '@/utils/ga/eventEnum';
 import { useMemberStore } from '@/zustand/store';
 
-const RecommendRoomComponent: React.FC = () => {
+import OpacityPressable from '../opacityPressable';
+
+export default function RecommendRoomComponent() {
   const router = useRouter();
   const { trackButton, trackGesture } = useTracker();
 
@@ -41,12 +42,12 @@ const RecommendRoomComponent: React.FC = () => {
           <Text className="Semibold18 text-emphasizedFont">꼭 맞는 방을 추천해드릴게요</Text>
         </View>
 
-        <Pressable onPress={handleMore}>
+        <OpacityPressable onPress={handleMore}>
           <View className="flex flex-row items-center gap-x-[4px]">
             <Text className="Semibold12 text-disabledFont">더보기</Text>
             <GrayArrowIcon />
           </View>
-        </Pressable>
+        </OpacityPressable>
       </View>
 
       {data.result.result.length !== 0 ? (
@@ -93,6 +94,4 @@ const RecommendRoomComponent: React.FC = () => {
       )}
     </View>
   );
-};
-
-export default RecommendRoomComponent;
+}

--- a/components/cozyHome/recommendRoommate.tsx
+++ b/components/cozyHome/recommendRoommate.tsx
@@ -1,7 +1,6 @@
 import { useRouter } from 'expo-router';
 import React, { Fragment } from 'react';
 import { Dimensions, Text, View } from 'react-native';
-import { Pressable } from 'react-native-gesture-handler';
 import { useSharedValue } from 'react-native-reanimated';
 import Carousel, { Pagination } from 'react-native-reanimated-carousel';
 
@@ -12,7 +11,9 @@ import { useTracker } from '@/providers/TrackerProvider';
 import { ButtonEvent, EventCategory, GestureEvent } from '@/utils/ga/eventEnum';
 import { useMemberStore } from '@/zustand/store';
 
-const RecommendRoommateComponent: React.FC = () => {
+import OpacityPressable from '../opacityPressable';
+
+export default function RecommendRoommateComponent() {
   const router = useRouter();
 
   const { memberInfo, hasLifeStyle } = useMemberStore();
@@ -54,12 +55,12 @@ const RecommendRoommateComponent: React.FC = () => {
               </Text>
             </View>
 
-            <Pressable onPress={handleMore}>
+            <OpacityPressable onPress={handleMore}>
               <View className="flex flex-row items-center gap-x-[4px]">
                 <Text className="Semibold12 text-disabledFont">더보기</Text>
                 <GrayArrowIcon />
               </View>
-            </Pressable>
+            </OpacityPressable>
           </View>
 
           {memberList.length !== 0 ? (
@@ -114,6 +115,4 @@ const RecommendRoommateComponent: React.FC = () => {
       </View>
     )
   );
-};
-
-export default RecommendRoommateComponent;
+}

--- a/components/cozyHome/sentRequest.tsx
+++ b/components/cozyHome/sentRequest.tsx
@@ -2,22 +2,21 @@ import { useRouter } from 'expo-router';
 import { Pressable, Text, View } from 'react-native';
 
 import GrayArrowIcon from '@/assets/images/common/grayArrow.svg';
-import { useCheckHasRoom } from '@/hooks/room/room';
 import { useGetSentRequestRoomList } from '@/hooks/room/user';
-
-import SimpleRoomItem from '../common/roomItem/simpleRoomItem';
 import { useMemberStore } from '@/zustand/store';
 
-const SentRequestComponent: React.FC = () => {
+import SimpleRoomItem from '../common/roomItem/simpleRoomItem';
+
+export default function SentRequestComponent() {
   const router = useRouter();
 
-  const { memberInfo, hasRoom } = useMemberStore();
+  const { memberInfo } = useMemberStore();
 
   const { data } = useGetSentRequestRoomList(3);
 
   return (
-    hasRoom &&
-    data.pages?.flatMap((page) => page.result.result).length !== 0 && (
+    data !== undefined &&
+    data.pages.flatMap((page) => page.result.result).length !== 0 && (
       <View>
         <View className="gap-y-[16px] px-[20px]">
           <View className="flex flex-row justify-between items-center">
@@ -49,6 +48,4 @@ const SentRequestComponent: React.FC = () => {
       </View>
     )
   );
-};
-
-export default SentRequestComponent;
+}

--- a/components/opacityPressable.tsx
+++ b/components/opacityPressable.tsx
@@ -1,0 +1,22 @@
+import { ReactNode, useState } from 'react';
+import { Pressable, PressableProps } from 'react-native';
+
+interface OpacityPressableProps extends PressableProps {
+  children: ReactNode;
+}
+
+export default function OpacityPressable({ children, onPress, ...rest }: OpacityPressableProps) {
+  const [isPressed, setIsPressed] = useState(false);
+
+  return (
+    <Pressable
+      onPressIn={() => setIsPressed(true)}
+      onPressOut={() => setIsPressed(false)}
+      onPress={onPress}
+      className={`${isPressed && 'opacity-60'}`}
+      {...rest}
+    >
+      {children}
+    </Pressable>
+  );
+}

--- a/hooks/room-recommend/room-recommend.ts
+++ b/hooks/room-recommend/room-recommend.ts
@@ -1,6 +1,5 @@
-import { useSuspenseInfiniteQuery, useSuspenseQuery } from '@tanstack/react-query';
+import { useInfiniteQuery, useSuspenseQuery } from '@tanstack/react-query';
 
-import { SortTypeValue } from '@/constants/items/sortItem';
 import { getRecommendRoomList } from '@/server/room-recommend/room-recommend';
 
 export const useGetHomeRecommendRoomList = () => {
@@ -10,13 +9,10 @@ export const useGetHomeRecommendRoomList = () => {
   });
 };
 
-export const useGetRecommendRoomList = (getSortType: () => SortTypeValue) => {
-  return useSuspenseInfiniteQuery({
+export const useGetRecommendRoomList = (sortType: string) => {
+  return useInfiniteQuery({
     queryKey: [`/rooms/list`],
-    queryFn: ({ pageParam = 0 }) => {
-      const sortType = getSortType();
-      return getRecommendRoomList(5, pageParam, sortType);
-    },
+    queryFn: ({ pageParam }) => getRecommendRoomList(5, pageParam, sortType),
     initialPageParam: 0,
     getNextPageParam: (lastPage) => {
       if (lastPage.result.hasNext) {

--- a/hooks/room/user.ts
+++ b/hooks/room/user.ts
@@ -1,7 +1,7 @@
 import {
+  useInfiniteQuery,
   useMutation,
   useQueryClient,
-  useSuspenseInfiniteQuery,
   useSuspenseQuery,
 } from '@tanstack/react-query';
 
@@ -48,7 +48,7 @@ export const useCheckIsInvitedRoom = (roomId: number) => {
 
 // 사용자가 참여 요청한 방 목록 조회
 export const useGetSentRequestRoomList = (size: number) => {
-  return useSuspenseInfiniteQuery({
+  return useInfiniteQuery({
     queryKey: [`/rooms/requested`, size],
     queryFn: ({ pageParam }) => getSentRequestRoomList(pageParam, size),
     initialPageParam: 0,


### PR DESCRIPTION
## 🚩 관련 이슈 (Jira)
[COZY-658] 코지홈 화면 리팩토링 작업

## 📌 반영 브랜치
COZY-658 -> dev

## 📋 내용
### 💻 코지홈
- [x] 상단 헤더의 방과 관련된 버튼을 제거했습니다. (방 만들기, 초대코드로 방 참여하기)
- [x] 헤더를 상단 고정하는 방식으로 수정했습니다.
- [x] 화면 최하단에 초대코드로 방 참여하는 새로운 버튼을 구현했습니다.

#### 라이프스타일이 없는 경우 (내부 칩은 무시해주세요)
<img src="https://github.com/user-attachments/assets/229237eb-39e6-4c19-89b8-044ef62c6237" width="250" />
<img src="https://github.com/user-attachments/assets/8d4c41e2-476c-4bfb-8524-00f153983e23" width="250" />

#### 라이프스타일이 있는 경우
<img src="https://github.com/user-attachments/assets/28801567-8181-4bcc-ab19-5144c7a578f3" width="250" />

---

### 💻 기타
- [x] 투명도 효과만으로 충분하여 TouchableOpacity 컴포넌트를 사용했던 부분이 있으나, Android 환경에서는 투명도 효과가 크지 않아서 투명도 효과가 확실한 커스텀 Pressable 컴포넌트를 구현했습니다.
<img src="https://github.com/user-attachments/assets/429c4df1-a63f-4550-a14b-0577c5886be8" width="250" />
<img src="https://github.com/user-attachments/assets/c9636930-1f4a-467e-b170-91d85bd36766" width="250" />
<img src="https://github.com/user-attachments/assets/68adae0d-7ec0-4fcf-a4fe-592d426c6c0b" width="250" />
<img src="https://github.com/user-attachments/assets/f5d99940-d470-494f-a142-833839ac896b" width="250" />

## 🚨 유의 사항
- [x] 없음

[COZY-658]: https://cozymate.atlassian.net/browse/COZY-658?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ