### PR TITLE
fix : 피드 레이아웃 관련 긴급 수정

### DIFF
--- a/app/feed/[id].tsx
+++ b/app/feed/[id].tsx
@@ -53,7 +53,7 @@ export default function PostDetail() {
   } = useToggle();
 
   return (
-    <DetailLayout>
+    <DetailLayout className="bg-white">
       {isLoading || isCommentListLoading ? (
         <LoadingComponent />
       ) : (

--- a/app/feed/create.tsx
+++ b/app/feed/create.tsx
@@ -5,6 +5,7 @@ import { useLocalSearchParams } from 'expo-router';
 import React, { useEffect } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import { Modal, ScrollView, Text, TextInput, View, Pressable } from 'react-native';
+import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
 import { z } from 'zod';
 
 import GalleryIcon from '@/assets/icons/feed/gallery.svg';
@@ -121,7 +122,7 @@ export default function CreateFeed() {
   };
 
   return (
-    <DetailLayout>
+    <DetailLayout className="bg-white">
       <View className="flex-1">
         <View className="px-5 pt-5 gap-y-4">
           <ScrollView

--- a/app/feed/create.tsx
+++ b/app/feed/create.tsx
@@ -5,7 +5,6 @@ import { useLocalSearchParams } from 'expo-router';
 import React, { useEffect } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import { Modal, ScrollView, Text, TextInput, View, Pressable } from 'react-native';
-import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
 import { z } from 'zod';
 
 import GalleryIcon from '@/assets/icons/feed/gallery.svg';

--- a/app/feed/edit.tsx
+++ b/app/feed/edit.tsx
@@ -46,7 +46,7 @@ export default function EditFeed() {
   const { mutate, isPending } = useUpdateMyRoomFeed();
 
   return (
-    <DetailLayout>
+    <DetailLayout className="bg-white">
       <View className="flex-1 px-5 pt-5 gap-y-12">
         <View className="gap-y-[12px]">
           <Text className="Semibold16 text-emphasizedFont mx-[4px]">피드 이름을 입력해주세요</Text>

--- a/app/feed/menu.tsx
+++ b/app/feed/menu.tsx
@@ -20,9 +20,8 @@ export default function Menu() {
 
     const menuItems = data?.result ? Object.entries(data.result).map(([k, v]) => [k as MenuTimeKey, v as DormitoryMenu]) as [MenuTimeKey, DormitoryMenu][] : [];
 
-    return <DetailLayout>
+    return <DetailLayout className="bg-[#F7FAFF]">
         <View className="mt-[8px]">
-
             <Carousel
                 width={Dimensions.get('window').width}
                 height={84}
@@ -89,39 +88,44 @@ export default function Menu() {
                 </Text>
                 {selectedDate === formatDateYYYYMMDD(today) && <Text className="Regular12 text-disabledFont ml-1">(오늘)</Text>}</View>
         } />
-        <View className="mt-[16px] gap-y-[12px] text-center w-full">
-            {(() => {
-                if (isAxiosError(error) && error.response?.data?.code === 'DORMITORYMENU400') {
-                    return <Text className="text-disabledFont w-full text-center">해당 날짜의 메뉴가 없습니다.</Text>
-                }
-                if (error) {
-                    return <Text className="text-disabledFont w-full text-center">메뉴를 불러오는 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.</Text>
-                }
-                if (isFetching && !data) {
-                    return (
-                        <>
-                            <Text className="text-disabledFont w-full text-center">메뉴를 불러오는 중입니다.</Text>
-                        </>
-                    );
-                }
-                if (isFetching && data) {
-                    return (
-                        <>
-                            <MenuItem menuItem={['breakfast', { time: '08:00~09:00', menu: '' }]} isFetching={true} />
-                        </>
-                    );
-                }
+        <View className="flex-1 gap-y-[12px] text-center items-start w-full">
+            {!isFetching && data && menuItems.length > 0 ?
+                <View className="gap-y-[12px] w-full pt-6">
+                    {menuItems.map((mi) => (
+                        <MenuItem key={mi[0]} menuItem={mi} isFetching={false} />
+                    ))}
+                </View>
+                :
+                <View className="flex items-center justify-center w-full h-full pb-60">
+                    {(() => {
+                        if (isAxiosError(error) && error.response?.data?.code === 'DORMITORYMENU400') {
+                            return <Text className="text-disabledFont w-full text-center">해당 날짜의 메뉴가 없습니다.</Text>
+                        }
+                        if (error) {
+                            return <Text className="text-disabledFont w-full text-center">메뉴를 불러오는 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.</Text>
+                        }
+                        if (isFetching && !data) {
+                            return (
+                                <>
+                                    <Text className="text-disabledFont w-full text-center">메뉴를 불러오는 중입니다.</Text>
+                                </>
+                            );
+                        }
+                        if (isFetching && data) {
+                            return (
+                                <>
+                                    <MenuItem menuItem={['breakfast', { time: '08:00~09:00', menu: '' }]} isFetching={true} />
+                                </>
+                            );
+                        }
 
-                if (menuItems.length === 0) {
-                    return <Text className="text-disabledFont w-full text-center">해당 날짜의 메뉴가 없습니다.</Text>
-                }
+                        if (menuItems.length === 0) {
+                            return <Text className="text-disabledFont w-full text-center">해당 날짜의 메뉴가 없습니다.</Text>
+                        }
 
-                return null;
-            })()}
-
-            {!isFetching && data && menuItems.length > 0 && menuItems.map((mi) => (
-                <MenuItem key={mi[0]} menuItem={mi} isFetching={false} />
-            ))}
+                        return null;
+                    })()}
+                </View>}
         </View>
     </DetailLayout>
 }

--- a/app/feed/notice.tsx
+++ b/app/feed/notice.tsx
@@ -13,7 +13,7 @@ export default function Notice() {
 
     const { data: noticeListData, isRefetching: isNoticeListFetching, error: noticeListError, fetchNextPage, hasNextPage, isFetchingNextPage, refetch: noticeListRefetch } = useGetDormitoryNoticeList();
 
-    return <DetailLayout>
+    return <DetailLayout className="bg-[#F7FAFF]">
         <FlatList
             refreshControl={<RefreshControl refreshing={isNoticeListFetching} onRefresh={() => { noticeListRefetch(); }} />}
             ListHeaderComponent={

--- a/components/common/dormitoryItem/menuItem.tsx
+++ b/components/common/dormitoryItem/menuItem.tsx
@@ -22,7 +22,7 @@ export const MenuItem = ({ menuItem, onPress = () => { }, isFetching = true }: M
 
     return (
         <OpacityPressable onPress={onPress} className='h-fit w-full'>
-            <View className="flex flex-col border border-disabledColor h-fit p-3 rounded-xl mx-[20px]">
+            <View className="flex flex-col border border-disabledColor h-fit p-3 rounded-xl mx-[20px] bg-white">
                 {isFetching ? (
                     <>
                         <View className="flex flex-row items-center justify-start">
@@ -41,7 +41,6 @@ export const MenuItem = ({ menuItem, onPress = () => { }, isFetching = true }: M
                     <>
                         <View className="flex flex-row items-center justify-start">
                             <View className="py-[2px] px-[8px] rounded bg-colorBox">
-                                {/* 자간 조정 */}
                                 <Text className="Medium12 text-colorFont leading-[14px]">{MENU_TIME_KEY_MAP[menuTime]}</Text>
                             </View>
                             <Text className="Medium12 text-basicFont mx-[8px]">
@@ -49,7 +48,7 @@ export const MenuItem = ({ menuItem, onPress = () => { }, isFetching = true }: M
                             </Text>
                         </View>
                         {/* @description 이런 문자열로 와서 임시 처리 로직 넣었습니다 \"백순대볶음*양념장\n쌀밥\n김치떡국\n새송이볶음\n무말랭이무침\n갓김치\" */}
-                        <Text className="text-basicFont mx-[8px] whitespace-nowrap mt-[8px]">
+                        <Text className="Medium14 text-emphasizedFont mx-[8px] whitespace-nowrap mt-[8px]">
                             {!menu || menu === "[]" || menu === "" ? "메뉴가 없습니다" : menu.replace(/\\n|["\[\]]/g, (m) => (m === '\\n' ? ' ' : ''))}
                         </Text>
                     </>

--- a/components/common/dormitoryItem/noticeItem.tsx
+++ b/components/common/dormitoryItem/noticeItem.tsx
@@ -16,7 +16,7 @@ export const NoticeItem = ({ noticeItem, isFetching = true }: NoticeItemProps) =
         // url 로 이동
         <OpacityPressable disabled={isFetching} onPress={isFetching ? () => { } : () => Linking.openURL(noticeItem.url)}>
 
-            <View className="border border-disabledColor px-[16px] pt-[20px] pb-[18px] rounded-xl mx-[20px]">
+            <View className="border border-disabledColor px-[16px] py-[12px] rounded-xl mx-[20px] bg-white">
                 {isFetching ? (
                     <>
                         <View className="flex flex-row justify-between items-center">
@@ -35,7 +35,7 @@ export const NoticeItem = ({ noticeItem, isFetching = true }: NoticeItemProps) =
                     </>
                 ) : (
                     <View className="flex flex-row justify-between items-center">
-                        <View className="flex-1 gap-1">
+                        <View className="flex-1 gap-2">
                             <View className="flex flex-row items-center justify-between">
                                 <Text className="Medium16 text-basicFont" numberOfLines={1} ellipsizeMode="tail">
                                     {noticeItem.title}

--- a/components/common/layout/detailLayout.tsx
+++ b/components/common/layout/detailLayout.tsx
@@ -1,15 +1,17 @@
-import { View } from 'react-native';
+import { Keyboard, TouchableWithoutFeedback, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 import BackHeaderComponent from '../backHeader';
 
 export const DetailLayout = ({ children, className }: { children: React.ReactNode, className?: string }) => {
     return (
-        <SafeAreaView className={`flex-1 bg-white ${className}`}>
-            <View className="px-5">
-                <BackHeaderComponent />
-            </View>
-            {children}
-        </SafeAreaView>
+        <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
+            <SafeAreaView className={`flex-1 ${className}`}>
+                <View className="px-5">
+                    <BackHeaderComponent />
+                </View>
+                {children}
+            </SafeAreaView>
+        </TouchableWithoutFeedback>
     );
 };


### PR DESCRIPTION
## 🚩 관련 이슈 (Jira)
[COZY-680] 

## 📌 반영 브랜치
COZY-680 -> dev

## 📋 내용

1) 공지사항, 메뉴 컴포넌트 fill값 흰색
2) 메뉴 컴포넌트 내의 메뉴 내역 font-weight medium으로 수정
3) empty 페이지 "해당 날짜의 메뉴가 없습니다." 상단 영역 80px 주기
4) 방 이름 설정 및 게시글 작성 후, 여백 클릭시 키패드 내림 필요
5) 일부 배경 일치하지 않는 곳 수정, DetailLayout에서 bg 제거


### 💻 스크린

## 🚨 유의 사항
- [ ] 방 상세 스크린 최하단의 버튼 미구현


[COZY-680]: https://cozymate.atlassian.net/browse/COZY-680?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **스타일 개선**
  * 피드 관련 화면(상세·생성·수정·메뉴·공지)과 메뉴/공지 아이템에 배경색(흰색/연파랑) 및 여백·간격·텍스트 강조 조정으로 시각 일관성 향상
* **사용성 개선**
  * 메뉴 목록이 있을 때 항목 우선 렌더링, 없을 땐 중앙 플레이스홀더 표시로 상태 표현 개선
  * 화면 터치 시 키보드 자동 닫기 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->